### PR TITLE
use non-root user for container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,5 @@ RUN CGO_ENABLED=0 go build -a -o config-reloader main.go
 FROM gcr.io/distroless/static:latest
 WORKDIR /
 COPY --from=builder /workspace/config-reloader .
+USER 65532:65532
 ENTRYPOINT ["/config-reloader"]


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes banzaicloud/logging-operator#1147
| License         | Apache 2.0


### What's in this PR?

make config container container to run as normal user

### Why?

With new config reloader image, fluentd can't start in restricted environment (when you forbid root user in your containers) using logging operator

### Additional context

N/A


### Checklist

- [x] Code meets the [Developer Guide](https://github.com/banzaicloud/developer-guide) --> I guess ^_^

