### PR TITLE
chore(deps): use major release in Dockerfile to automatically pick minor revision on rebuilds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.1 as builder
+FROM golang:1.20 as builder
 
 WORKDIR /workspace
 


### PR DESCRIPTION
Do not pin to minor version in dockerfile to allow automatic minor version bumps on rebuilds